### PR TITLE
CBP-21065 [BE] Replace all usages of /v2/workflows/runs/artifactinfos in actions with /v3/artifactinfos

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -29,7 +29,7 @@ runs:
   steps:
     - id: run-jfrog-download-action
       name: run-jfrog-download-action
-      uses: docker://public.ecr.aws/l7o7z1g8/actions/jfrog-actions:main-fd246058f87ac46255af92aa41cbad9a5c8d5c1c
+      uses: docker://public.ecr.aws/l7o7z1g8/actions/jfrog-actions:main-7b49cb1e4dee9a4a2db3f8c020997ebf2957968e
       shell: sh
       env:
         CONFIG_JSON: '{"metaInfo":{"srcType":"download","url":"${{ inputs.url }}","username":"${{ inputs.username }}","password":"${{ inputs.password }}","token":"${{ inputs.token }}","artifactoryPath":"${{ inputs.artifactory-path }}","filePath":"${{ inputs.file-path }}"}}'

--- a/action.yml
+++ b/action.yml
@@ -29,7 +29,7 @@ runs:
   steps:
     - id: run-jfrog-download-action
       name: run-jfrog-download-action
-      uses: docker://public.ecr.aws/l7o7z1g8/actions/jfrog-actions:main-6fd28fb7843147f71ef3e0743f5755473c7e4942
+      uses: docker://public.ecr.aws/l7o7z1g8/actions/jfrog-actions:main-fd246058f87ac46255af92aa41cbad9a5c8d5c1c
       shell: sh
       env:
         CONFIG_JSON: '{"metaInfo":{"srcType":"download","url":"${{ inputs.url }}","username":"${{ inputs.username }}","password":"${{ inputs.password }}","token":"${{ inputs.token }}","artifactoryPath":"${{ inputs.artifactory-path }}","filePath":"${{ inputs.file-path }}"}}'


### PR DESCRIPTION
I've verified that fresh jfrog-actions docker image for commit https://github.com/calculi-corp/jfrog-repo-actions/commit/fd246058f87ac46255af92aa41cbad9a5c8d5c1c is already publicly available:

```
docker image pull public.ecr.aws/l7o7z1g8/actions/jfrog-actions:main-7b49cb1e4dee9a4a2db3f8c020997ebf2957968e
main-7b49cb1e4dee9a4a2db3f8c020997ebf2957968e: Pulling from l7o7z1g8/actions/jfrog-actions
35d697fe2738: Already exists
bfb59b82a9b6: Already exists
4eff9a62d888: Already exists
62de241dac5f: Already exists
2780920e5dbf: Already exists
7c12895b777b: Already exists
3214acf345c0: Already exists
5664b15f108b: Already exists
045fc1c20da8: Already exists
4aa0ea1413d3: Already exists
da7816fa955e: Already exists
ddf74a63f7d8: Already exists
848d0bc22381: Pull complete
a2b54f99b8b8: Pull complete
5164da205226: Pull complete
Digest: sha256:24ce8a693d765bfb43913728bd586c851dccbbf5da4327e8c8311f07c3845f3d
Status: Downloaded newer image for public.ecr.aws/l7o7z1g8/actions/jfrog-actions:main-7b49cb1e4dee9a4a2db3f8c020997ebf2957968e
public.ecr.aws/l7o7z1g8/actions/jfrog-actions:main-7b49cb1e4dee9a4a2db3f8c020997ebf2957968e
```